### PR TITLE
fix link issue with latest stable version of tensorflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,18 @@ cmake_minimum_required(VERSION 2.8)
 
 # get tensorflow include dirs, see https://www.tensorflow.org/how_tos/adding_an_op/
 execute_process(COMMAND python3 -c "import tensorflow; print(tensorflow.sysconfig.get_include())" OUTPUT_VARIABLE Tensorflow_INCLUDE_DIRS)
+execute_process(COMMAND python3 -c "import tensorflow as tf; print(' '.join(tf.sysconfig.get_link_flags()), end='')" OUTPUT_VARIABLE Tensorflow_LINK_FLAGS)
+execute_process(COMMAND python3 -c "import tensorflow as tf; print(' '.join(tf.sysconfig.get_compile_flags()), end='')" OUTPUT_VARIABLE Tensorflow_COMPILE_FLAGS)
+
 
 # C++11 required for tensorflow
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 ${Tensorflow_COMPILE_FLAGS} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-as-needed ${Tensorflow_LINK_FLAGS} ${CMAKE_SHARED_LINKER_FLAGS}")
 
 # if GCC > 5
-if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 5.0)
-  set(CMAKE_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=0 ${CMAKE_CXX_FLAGS}")
-endif()
+# if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 5.0)
+#   set(CMAKE_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=0 ${CMAKE_CXX_FLAGS}")
+# endif()
 
 # build the actual operation which can be used directory
 include_directories(${Tensorflow_INCLUDE_DIRS})

--- a/_inner_product_grad.py
+++ b/_inner_product_grad.py
@@ -9,7 +9,7 @@ import tensorflow as tf
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import sparse_ops
-inner_product_grad_module = tf.load_op_library('build/libinner_product_grad.so')
+inner_product_grad_module = tf.load_op_library('libinner_product_grad.so')
 
 @ops.RegisterGradient("InnerProduct")
 def _inner_product_grad_cc(op, grad):
@@ -47,3 +47,6 @@ def _inner_product_grad(op, grad):
     
     return [tf.transpose(grad_input), grad_weights]
   
+
+
+

--- a/inner_product_tests.py
+++ b/inner_product_tests.py
@@ -9,7 +9,7 @@ import unittest
 import numpy as np
 import tensorflow as tf
 import _inner_product_grad
-inner_product_module = tf.load_op_library('build/libinner_product.so')
+inner_product_module = tf.load_op_library('libinner_product.so')
 
 class InnerProductOpTest(unittest.TestCase):
     def test_raisesExceptionWithIncompatibleDimensions(self):


### PR DESCRIPTION
This seems to fix the compile flags for the latest tensorflow/tensorflow:nightly-devel-py3 docker image

